### PR TITLE
fix: remove device specific search appearance on iOS

### DIFF
--- a/src/components/SearchBox/index.tsx
+++ b/src/components/SearchBox/index.tsx
@@ -7,7 +7,7 @@ const SearchBox = (): JSX.Element => {
         id="search"
         type="search"
         placeholder="Search"
-        className="z-10 w-0 h-12 text-lg duration-300 rounded-l-sm outline-none md:w-[calc(100%_-_3rem+_1px)] peer md:px-5 focus:px-5 focus:w-[calc(100%_-_3rem+_1px)] pointer-events-auto"
+        className="z-10 w-0 h-12 text-lg duration-300 rounded-l-sm outline-none md:w-[calc(100%_-_3rem+_1px)] peer md:px-5 focus:px-5 focus:w-[calc(100%_-_3rem+_1px)] pointer-events-auto bg-white"
       />
       <label
         htmlFor="search"

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,10 @@
   h3 {
     @apply text-lg font-medium;
   }
+  [type='search'] {
+    -webkit-appearance: none;
+    -webkit-border-radius: initial;
+  }
 }
 
 @tailwind components;


### PR DESCRIPTION
For some reason tailwind preflight does not css-reset device-specific input appearance settings on iOS hence it is impossible to customize the border radius with standard tailwind classes.