### PR TITLE
refactor: SwipeToAction to handle different left/right swipe action & ui

### DIFF
--- a/src/components/SwipeToAction/index.tsx
+++ b/src/components/SwipeToAction/index.tsx
@@ -1,26 +1,32 @@
 import { useRef, useState } from 'react';
 import type { SwipeCallback, SwipeDirections, TapCallback } from 'react-swipeable';
-import { useSwipeable, LEFT } from 'react-swipeable';
+import { useSwipeable, LEFT, RIGHT } from 'react-swipeable';
 import { BackgroundLayer } from './BackgroundLayer';
 import { ForegroundLayer } from './ForegroundLayer';
 
 // TODO: consider twin.macro for this component?
 const SwipeToAction = ({
   children,
-  backgroundChildren,
+  leftChildren,
+  rightChildren,
   threshold = 0.3,
-  onSwiped,
+  onSwipedLeft,
+  onSwipedRight,
   onTap,
-  backgroundClassName,
-  foregroundClassName,
+  leftChildrenClassName,
+  rightChildrenClassName,
+  className,
 }: {
   children: React.ReactNode;
-  backgroundChildren: React.ReactNode;
+  leftChildren: React.ReactNode;
+  rightChildren: React.ReactNode;
   threshold?: number;
-  onSwiped?: SwipeCallback;
+  onSwipedLeft?: SwipeCallback;
+  onSwipedRight?: SwipeCallback;
   onTap?: TapCallback;
-  backgroundClassName?: string;
-  foregroundClassName?: string;
+  leftChildrenClassName?: string;
+  rightChildrenClassName?: string;
+  className?: string;
 }): JSX.Element => {
   const foregroundRef = useRef<HTMLDivElement | null>(null);
   const backgroundRef = useRef<HTMLDivElement | null>(null);
@@ -59,8 +65,10 @@ const SwipeToAction = ({
       if (Math.abs(left) >= offsetWidth * threshold) {
         left = eventData.dir === LEFT ? -offsetWidth * 2 : offsetWidth;
 
-        if (onSwiped) {
-          onSwiped(eventData);
+        if (eventData.dir === LEFT && onSwipedLeft) {
+          onSwipedLeft(eventData);
+        } else if (eventData.dir === RIGHT && onSwipedRight) {
+          onSwipedRight(eventData);
         }
       } else {
         left = 0;
@@ -78,11 +86,15 @@ const SwipeToAction = ({
 
   return (
     <div className="relative w-full overflow-hidden">
-      <BackgroundLayer ref={backgroundRef} className={backgroundClassName} swipeDirection={swipeDirection}>
-        {backgroundChildren}
+      <BackgroundLayer
+        ref={backgroundRef}
+        className={swipeDirection === LEFT ? rightChildrenClassName : leftChildrenClassName}
+        swipeDirection={swipeDirection}
+      >
+        {swipeDirection === LEFT ? rightChildren : leftChildren}
       </BackgroundLayer>
       {/* eslint-disable-next-line @typescript-eslint/unbound-method */}
-      <ForegroundLayer ref={refPassthrough} className={foregroundClassName} onMouseDown={swipeableHandlers.onMouseDown}>
+      <ForegroundLayer ref={refPassthrough} className={className} onMouseDown={swipeableHandlers.onMouseDown}>
         {children}
       </ForegroundLayer>
     </div>

--- a/src/routes/tasks/TodoItem/index.tsx
+++ b/src/routes/tasks/TodoItem/index.tsx
@@ -53,11 +53,14 @@ const TodoItem = ({
   return (
     <li className="w-full mb-3 last:mb-20 xs:w-56 md:w-60">
       <SwipeToAction
+        className="bg-[#F5F9FF] border rounded-lg border-slate-300 px-3 pb-3"
         onTap={toggleItem}
-        onSwiped={deleteItem}
-        backgroundChildren={<TrashIcon className="w-6 h-6" />}
-        backgroundClassName="bg-red-700 text-white border rounded-lg"
-        foregroundClassName="bg-[#F5F9FF] border rounded-lg border-slate-300 px-3 pb-3"
+        onSwipedLeft={deleteItem}
+        onSwipedRight={deleteItem}
+        leftChildren={<TrashIcon className="w-6 h-6" />}
+        leftChildrenClassName="bg-red-700 text-white border rounded-lg"
+        rightChildren={<TrashIcon className="w-6 h-6" />}
+        rightChildrenClassName="bg-red-700 text-white border rounded-lg"
       >
         <h3 className={`${data.done ? 'line-through text-[#6B7385]' : ''}`}>{`Lorem Ipsum #${data.id}`}</h3>
         <label className={`flex line-clamp-3 ${data.done ? 'line-through text-[#6B7385]' : ''}`}>{data.task}</label>


### PR DESCRIPTION
Enabling SwipeToAction component to handle left / right swipe in different way (both action & ui) allows us to optionally implement delete / archive commands in the future. Originally I was planning on delete / edit but on a second thought "edit" swipe command that opens a modal ui seems like the wrong UX pattern (swipe action should be contextual and not navigate away from the list view).