### PR TITLE
refactor: add headroom/legroom wrapper elements

### DIFF
--- a/src/components/Headroom/Headroom.tsx
+++ b/src/components/Headroom/Headroom.tsx
@@ -1,10 +1,10 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { useHeadroom } from './hooks/useHeadroom';
 
-const Headroom = ({ children }: { children: React.ReactElement }): JSX.Element => {
-  const rootRef = useRef<HTMLElement | null>(null);
+const Headroom = ({ children, className = '' }: { children: React.ReactNode; className?: string }): JSX.Element => {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
-  useHeadroom(rootRef, {
+  useHeadroom(wrapperRef, {
     headroomOptions: {
       classes: {
         initial: 'transition-transform duration-300 will-change-transform',
@@ -17,9 +17,11 @@ const Headroom = ({ children }: { children: React.ReactElement }): JSX.Element =
     disableInitialTransitionToUnpinned: true,
   });
 
-  const childElement = React.Children.only(children);
-
-  return React.cloneElement(childElement, { ref: rootRef });
+  return (
+    <div className={className} ref={wrapperRef}>
+      {children}
+    </div>
+  );
 };
 
 export { Headroom };

--- a/src/components/Headroom/Legroom.tsx
+++ b/src/components/Headroom/Legroom.tsx
@@ -1,10 +1,10 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { useHeadroom } from './hooks/useHeadroom';
 
-const Legroom = ({ children }: { children: React.ReactElement }): JSX.Element => {
-  const rootRef = useRef<HTMLElement | null>(null);
+const Legroom = ({ children, className = '' }: { children: React.ReactNode; className?: string }): JSX.Element => {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
-  useHeadroom(rootRef, {
+  useHeadroom(wrapperRef, {
     headroomOptions: {
       classes: {
         initial: 'fixed inset-x-0 bottom-0 transition-transform duration-300 will-change-transform',
@@ -14,9 +14,11 @@ const Legroom = ({ children }: { children: React.ReactElement }): JSX.Element =>
     },
   });
 
-  const childElement = React.Children.only(children);
-
-  return React.cloneElement(childElement, { ref: rootRef });
+  return (
+    <div className={className} ref={wrapperRef}>
+      {children}
+    </div>
+  );
 };
 
 export { Legroom };

--- a/src/routes/layout/Header/index.tsx
+++ b/src/routes/layout/Header/index.tsx
@@ -1,13 +1,12 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { atom, useAtom } from 'jotai';
 import type { ChangeEvent } from 'react';
-import { forwardRef } from 'react';
 import { Navigation } from '../Navigation';
 import { SearchBox } from '../../../components/SearchBox';
 
 export const queryAtom = atom('');
 
-const Header = forwardRef<HTMLElement>((_, ref) => {
+const Header = (): JSX.Element => {
   const [query, setQuery] = useAtom(queryAtom);
   const location = useLocation();
   const navigate = useNavigate();
@@ -20,7 +19,7 @@ const Header = forwardRef<HTMLElement>((_, ref) => {
   };
 
   return (
-    <header ref={ref} className="z-10 w-screen bg-sky-700">
+    <header className="w-screen bg-sky-700">
       <div className="flex items-center justify-between p-4">
         <div className="grid items-center w-full md:flex">
           <div className="flex justify-start col-start-1 row-start-1 md:mr-4">
@@ -38,6 +37,6 @@ const Header = forwardRef<HTMLElement>((_, ref) => {
       </div>
     </header>
   );
-});
+};
 
 export { Header };

--- a/src/routes/layout/Navigation/index.tsx
+++ b/src/routes/layout/Navigation/index.tsx
@@ -1,5 +1,4 @@
 import { AdjustmentsIcon, ChartSquareBarIcon, ClipboardListIcon } from '@heroicons/react/outline';
-import { forwardRef } from 'react';
 import { NavLink } from 'react-router-dom';
 
 export const navigationItems = ['tasks', 'analytics', 'settings'];
@@ -17,9 +16,9 @@ const mapNavigationIcon = (item: string): JSX.Element => {
   }
 };
 
-const BottomNavigation = forwardRef<HTMLElement>((_, ref) => {
+const BottomNavigation = (): JSX.Element => {
   return (
-    <nav ref={ref} className="z-10 flex justify-between text-xs text-blue-900 bg-blue-100 md:hidden">
+    <nav className="flex justify-between text-xs text-blue-900 bg-blue-100 md:hidden">
       {navigationItems.map((item) => (
         <NavLink
           key={item}
@@ -36,7 +35,7 @@ const BottomNavigation = forwardRef<HTMLElement>((_, ref) => {
       ))}
     </nav>
   );
-});
+};
 
 const Navigation = (): JSX.Element => {
   return (

--- a/src/routes/layout/index.tsx
+++ b/src/routes/layout/index.tsx
@@ -7,13 +7,13 @@ const Layout = (): JSX.Element => {
   return (
     // NOTE: cannot use Fragment here as it will break the sticky header
     <div>
-      <Headroom>
+      <Headroom className="z-10">
         <Header />
       </Headroom>
       <main>
         <Outlet />
       </main>
-      <Legroom>
+      <Legroom className="z-10">
         <BottomNavigation />
       </Legroom>
     </div>


### PR DESCRIPTION
Introduce headroom / legroom wrapper divs to improve UX:

1. Not require content to be single child
2. Not require functional components used as content to implement [ref forwarding](https://reactjs.org/docs/forwarding-refs.html) in order to fix the `Function components cannot be given refs` error.