### PR TITLE
feat: add support for dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "graphql": "^16.2.0",
         "headroom.js": "^0.12.0",
         "husky": "^7.0.4",
+        "jest-matchmedia-mock": "^1.1.0",
         "jotai": "^1.5.3",
         "lint-staged": "^12.1.5",
         "postcss": "^8.4.5",
@@ -11999,6 +12000,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-matchmedia-mock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jest-matchmedia-mock/-/jest-matchmedia-mock-1.1.0.tgz",
+      "integrity": "sha512-REnJRsOSCMpGAlkxmvVTqEBpregyFVi9MPEH3N83W1yLKzDdNehtCkcdDZduXq74PLtfI+11NyM4zKCK5ynV9g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "jest": ">=13"
       }
     },
     "node_modules/jest-message-util": {
@@ -29248,6 +29260,12 @@
           }
         }
       }
+    },
+    "jest-matchmedia-mock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jest-matchmedia-mock/-/jest-matchmedia-mock-1.1.0.tgz",
+      "integrity": "sha512-REnJRsOSCMpGAlkxmvVTqEBpregyFVi9MPEH3N83W1yLKzDdNehtCkcdDZduXq74PLtfI+11NyM4zKCK5ynV9g==",
+      "requires": {}
     },
     "jest-message-util": {
       "version": "27.4.6",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "graphql": "^16.2.0",
     "headroom.js": "^0.12.0",
     "husky": "^7.0.4",
+    "jest-matchmedia-mock": "^1.1.0",
     "jotai": "^1.5.3",
     "lint-staged": "^12.1.5",
     "postcss": "^8.4.5",

--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,19 @@
       })(window.location);
     </script>
     <!-- End Single Page Apps for GitHub Pages -->
+
+    <!-- Start Dark Mode Initialization -->
+    <script>
+      if (
+        localStorage.getItem('color-mode') === 'dark' ||
+        (!('color-mode' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+      ) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+    </script>
+    <!-- End Dark Mode Initialization -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -4,15 +4,17 @@ import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
 import { queryClient } from '../queryClient';
 
-test('renders todo app link', () => {
-  render(
-    <BrowserRouter basename={process.env.PUBLIC_URL}>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    </BrowserRouter>,
-  );
+describe('Todo App', () => {
+  test('renders todo app link', () => {
+    render(
+      <BrowserRouter basename={process.env.PUBLIC_URL}>
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+      </BrowserRouter>,
+    );
 
-  const linkElement = screen.getByText(/todo app/i);
-  expect(linkElement).toBeInTheDocument();
+    const linkElement = screen.getByText(/todo app/i);
+    expect(linkElement).toBeInTheDocument();
+  });
 });

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -24,7 +24,7 @@ const App = (): JSX.Element => {
           <Route
             path="tasks/*"
             element={
-              <Suspense fallback={<LoadingIndicator className="text-blue-900" />}>
+              <Suspense fallback={<LoadingIndicator className="text-primary" />}>
                 <Tasks />
               </Suspense>
             }
@@ -32,7 +32,7 @@ const App = (): JSX.Element => {
           <Route
             path="analytics"
             element={
-              <Suspense fallback={<LoadingIndicator className="text-blue-900" />}>
+              <Suspense fallback={<LoadingIndicator className="text-primary" />}>
                 <Analytics />
               </Suspense>
             }
@@ -40,7 +40,7 @@ const App = (): JSX.Element => {
           <Route
             path="settings"
             element={
-              <Suspense fallback={<LoadingIndicator className="text-blue-900" />}>
+              <Suspense fallback={<LoadingIndicator className="text-primary" />}>
                 <Settings />
               </Suspense>
             }

--- a/src/App/ErrorFallback.tsx
+++ b/src/App/ErrorFallback.tsx
@@ -8,14 +8,14 @@ const ErrorFallback = ({
   return (
     <main className="flex items-center justify-center max-w-2xl min-h-screen p-3 mx-auto">
       <div role="alert">
-        <div className="px-4 py-2 font-bold text-white bg-red-500 rounded-t">Oops!</div>
-        <div className="flex flex-col px-4 py-3 text-red-700 bg-red-100 border border-t-0 border-red-400 rounded-b">
+        <div className="px-4 py-2 font-bold rounded-t text-on-error bg-error">Oops!</div>
+        <div className="flex flex-col px-4 py-3 border border-t-0 rounded-b border-error text-on-error-container bg-error-container">
           <h3>Something went wrong:</h3>
-          <pre className="whitespace-pre-wrap">{error.message}</pre>
+          <pre className="break-all whitespace-pre-wrap">{error.message}</pre>
           <button
             type="button"
             onClick={resetErrorBoundary}
-            className="mx-auto mt-5 w-24 h-12 text-red-700 hover:text-white border border-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center whitespace-nowrap bg-red-50"
+            className="mx-auto mt-5 w-24 h-12 text-error hover:text-on-error border border-error hover:bg-error focus:ring-4 focus:ring-error/25 font-medium rounded-lg text-sm px-5 py-2.5 text-center whitespace-nowrap bg-on-error"
           >
             Try again
           </button>

--- a/src/components/SearchBox/index.tsx
+++ b/src/components/SearchBox/index.tsx
@@ -16,13 +16,13 @@ const SearchBox = ({
         value={value}
         onChange={onChange}
         placeholder="Search"
-        className="z-10 w-0 h-12 text-lg duration-300 rounded-l-sm outline-none md:w-[calc(100%_-_3rem+_1px)] peer md:px-5 focus:px-5 focus:w-[calc(100%_-_3rem+_1px)] pointer-events-auto bg-white"
+        className="z-10 w-0 h-12 text-lg duration-300 rounded-l-sm outline-none md:w-[calc(100%_-_3rem+_1px)] peer md:px-5 focus:px-5 focus:w-[calc(100%_-_3rem+_1px)] pointer-events-auto bg-primary-container  text-on-primary-container placeholder-on-primary-container/40"
       />
       <label
         htmlFor="search"
-        className="p-3 -ml-px bg-white rounded-sm pointer-events-auto select-none peer-focus:rounded-l-none md:rounded-l-none peer-focus:pointer-events-none"
+        className="p-3 -ml-px rounded-sm pointer-events-auto select-none bg-primary-container peer-focus:rounded-l-none md:rounded-l-none peer-focus:pointer-events-none text-on-primary-container"
       >
-        <SearchIcon className="w-6 h-6 pointer-events-none" />
+        <SearchIcon className="w-6 h-6 pointer-events-none text-on-primary-container" />
       </label>
     </div>
   );

--- a/src/components/ThemeToggle/index.tsx
+++ b/src/components/ThemeToggle/index.tsx
@@ -1,0 +1,21 @@
+import { MoonIcon, SunIcon } from '@heroicons/react/solid';
+import { ColorMode, useColorMode } from './useColorMode';
+
+const ThemeToggle = ({ className = '' }: { className?: string }): JSX.Element => {
+  const [colorMode, setColorMode] = useColorMode();
+  const isDarkMode = colorMode === ColorMode.Dark;
+
+  return (
+    <button
+      type="button"
+      onClick={() => setColorMode(isDarkMode ? ColorMode.Light : ColorMode.Dark)}
+      aria-label="Toggle Theme"
+      className={`text-on-primary/75 ring-0 hover:text-background rounded-full text-sm p-2.5 ${className}`}
+    >
+      <SunIcon className={`${!isDarkMode ? 'hidden' : ''} w-5 h-5`} />
+      <MoonIcon className={`${isDarkMode ? 'hidden' : ''} w-5 h-5`} />
+    </button>
+  );
+};
+
+export { ThemeToggle };

--- a/src/components/ThemeToggle/useColorMode.ts
+++ b/src/components/ThemeToggle/useColorMode.ts
@@ -1,0 +1,34 @@
+import { useMediaQuery } from '@react-hook/media-query';
+import type { Dispatch, SetStateAction } from 'react';
+import { useEffect } from 'react';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
+
+enum ColorMode {
+  Light = 'light',
+  Dark = 'dark',
+}
+
+const useColorMode = (): readonly [ColorMode, Dispatch<SetStateAction<ColorMode>>] => {
+  const isDarkModePreferred = useMediaQuery('(prefers-color-scheme: dark)');
+  const [colorMode, setColorMode] = useLocalStorage<ColorMode>(
+    'color-mode',
+    isDarkModePreferred ? ColorMode.Dark : ColorMode.Light,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const root = window.document.documentElement;
+    if (colorMode === ColorMode.Dark) {
+      root.classList.add(ColorMode.Dark);
+    } else {
+      root.classList.remove(ColorMode.Dark);
+    }
+  }, [colorMode]);
+
+  return [colorMode, setColorMode] as const;
+};
+
+export { useColorMode, ColorMode };

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,22 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useEffect, useState } from 'react';
+
+const useLocalStorage = <T>(key: string, defaultValue: T): readonly [T, Dispatch<SetStateAction<T>>] => {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return defaultValue;
+    }
+
+    const storedValue = window.localStorage.getItem(key);
+
+    return storedValue != null ? <T>JSON.parse(storedValue) : defaultValue;
+  });
+
+  useEffect(() => {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+
+  return [value, setValue] as const;
+};
+
+export { useLocalStorage };

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,61 @@
     -webkit-appearance: none;
     -webkit-border-radius: initial;
   }
+
+  /* material theme colors generated with https://material-foundation.github.io/material-theme-builder/#/custom */
+  :root {
+    --color-primary: 0 102 136;
+    --color-primary-variant: 0 73 104;
+    --color-on-primary: 255 255 255;
+    --color-primary-container: 224 243 255; /* 190 232 255; */
+    --color-on-primary-container: 0 30 43;
+    --color-secondary: 184 32 0;
+    --color-on-secondary: 255 255 255;
+    --color-secondary-container: 255 218 209;
+    --color-on-secondary-container: 63 4 0;
+    --color-tertiary: 152 65 99;
+    --color-on-tertiary: 255 255 255;
+    --color-tertiary-container: 255 216 228;
+    --color-on-tertiary-container: 62 0 29;
+    --color-error: 179 38 30;
+    --color-on-error: 255 255 255;
+    --color-error-container: 249 222 220;
+    --color-on-error-container: 65 14 11;
+    --color-background: 255 251 247;
+    --color-on-background: 29 27 22;
+    --color-surface: 255 251 254;
+    --color-on-surface: 29 27 22;
+    --color-outline: 121 116 126;
+    --color-surface-variant: 231 224 236;
+    --color-on-surface-variant: 73 69 79;
+  }
+
+  :root.dark {
+    --color-primary: 110 210 255;
+    --color-primary-variant: 190 232 255;
+    --color-on-primary: 0 53 73;
+    --color-primary-container: 0 77 104;
+    --color-on-primary-container: 190 232 255;
+    --color-secondary: 255 180 162;
+    --color-on-secondary: 101 11 0;
+    --color-secondary-container: 141 20 0;
+    --color-on-secondary-container: 255 218 209;
+    --color-tertiary: 255 176 203;
+    --color-on-tertiary: 93 17 52;
+    --color-tertiary-container: 122 41 75;
+    --color-on-tertiary-container: 255 216 228;
+    --color-error: 242 184 181;
+    --color-on-error: 96 20 16;
+    --color-error-container: 140 29 24;
+    --color-on-error-container: 249 222 220;
+    --color-background: 29 27 22;
+    --color-on-background: 232 226 217;
+    --color-surface: 29 27 22;
+    --color-on-surface: 232 226 217;
+    --color-outline: 147 143 153;
+    --color-surface-variant: 73 69 79;
+    --color-on-surface-variant: 202 196 208;
+  }
 }
 
 @tailwind components;

--- a/src/routes/analytics/index.tsx
+++ b/src/routes/analytics/index.tsx
@@ -1,6 +1,6 @@
 const Analytics = (): JSX.Element => {
   return (
-    <div className="min-h-screen p-4 bg-green-100">
+    <div className="min-h-screen p-4 transition-colors bg-background text-on-background">
       <p>Analytics</p>
     </div>
   );

--- a/src/routes/layout/Header/index.tsx
+++ b/src/routes/layout/Header/index.tsx
@@ -3,6 +3,7 @@ import { atom, useAtom } from 'jotai';
 import type { ChangeEvent } from 'react';
 import { Navigation } from '../Navigation';
 import { SearchBox } from '../../../components/SearchBox';
+import { ThemeToggle } from '../../../components/ThemeToggle';
 
 export const queryAtom = atom('');
 
@@ -19,12 +20,12 @@ const Header = (): JSX.Element => {
   };
 
   return (
-    <header className="w-screen bg-sky-700">
+    <header className="w-screen transition-colors bg-primary">
       <div className="flex items-center justify-between p-4">
         <div className="grid items-center w-full md:flex">
           <div className="flex justify-start col-start-1 row-start-1 md:mr-4">
             <Link to="/">
-              <span className="text-xl font-semibold text-white">Todo App</span>
+              <span className="text-xl font-semibold text-on-primary">Todo App</span>
             </Link>
           </div>
 
@@ -33,7 +34,9 @@ const Header = (): JSX.Element => {
           </form>
         </div>
 
-        <Navigation />
+        <Navigation className="hidden md:flex" />
+
+        <ThemeToggle className="hidden md:block" />
       </div>
     </header>
   );

--- a/src/routes/layout/Navigation/index.tsx
+++ b/src/routes/layout/Navigation/index.tsx
@@ -16,17 +16,15 @@ const mapNavigationIcon = (item: string): JSX.Element => {
   }
 };
 
-const BottomNavigation = (): JSX.Element => {
+const BottomNavigation = ({ className = '' }: { className?: string }): JSX.Element => {
   return (
-    <nav className="flex justify-between text-xs text-blue-900 bg-blue-100 md:hidden">
+    <nav className={`flex justify-between text-xs bg-primary text-on-primary ${className}`}>
       {navigationItems.map((item) => (
         <NavLink
           key={item}
           to={`/${item}`}
           className={({ isActive }) =>
-            `w-full p-3 text-center transition duration-300 ${
-              isActive ? 'bg-blue-200 text-blue-800' : ''
-            } hover:bg-blue-200 hover:text-blue-800`
+            `w-full p-3 text-center transition duration-300 ${isActive ? 'bg-primary-variant text-on-primary' : ''}`
           }
         >
           {mapNavigationIcon(item)}
@@ -37,15 +35,11 @@ const BottomNavigation = (): JSX.Element => {
   );
 };
 
-const Navigation = (): JSX.Element => {
+const Navigation = ({ className = '' }: { className?: string }): JSX.Element => {
   return (
-    <nav className="items-center hidden w-auto md:flex">
+    <nav className={`items-center w-auto text-on-primary ${className}`}>
       {navigationItems.map((item) => (
-        <NavLink
-          key={item}
-          className={({ isActive }) => `block mr-4 md:text-white ${isActive ? 'underline' : ''}`}
-          to={`/${item}`}
-        >
+        <NavLink key={item} className={({ isActive }) => `block mr-4 ${isActive ? 'underline' : ''}`} to={`/${item}`}>
           <span className="capitalize">{item}</span>
         </NavLink>
       ))}

--- a/src/routes/layout/index.tsx
+++ b/src/routes/layout/index.tsx
@@ -14,7 +14,7 @@ const Layout = (): JSX.Element => {
         <Outlet />
       </main>
       <Legroom className="z-10">
-        <BottomNavigation />
+        <BottomNavigation className="md:hidden" />
       </Legroom>
     </div>
   );

--- a/src/routes/notFound/index.tsx
+++ b/src/routes/notFound/index.tsx
@@ -1,6 +1,6 @@
 const NotFound = (): JSX.Element => {
   return (
-    <div className="h-full p-4 bg-red-100">
+    <div className="min-h-screen p-4 bg-error-container text-on-error-container">
       <p>There&apos;s nothing here!</p>
     </div>
   );

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -1,7 +1,12 @@
+import { ThemeToggle } from '../../components/ThemeToggle';
+
 const Settings = (): JSX.Element => {
   return (
-    <div className="min-h-screen p-4 bg-violet-100">
-      <p>Settings</p>
+    <div className="min-h-screen p-4 transition-colors text-on-tertiary bg-tertiary">
+      <div className="flex items-center gap-2 md:hidden">
+        <span>Toggle theme:</span>
+        <ThemeToggle />
+      </div>
     </div>
   );
 };

--- a/src/routes/taskNew/AddNewForm/index.tsx
+++ b/src/routes/taskNew/AddNewForm/index.tsx
@@ -49,23 +49,23 @@ const AddNewForm = ({ onSubmitted, onCancel }: { onSubmitted: () => void; onCanc
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form className="bg-surface" onSubmit={handleSubmit(onSubmit)}>
       <div className="relative">
         <input
           id="title"
           type="text"
           placeholder="Title"
           {...register('title')}
-          className="w-full h-12 px-3 text-lg text-gray-900 placeholder-transparent border border-gray-300 rounded-md outline-blue-700 bg-gray-50 focus:border-blue-500 peer"
+          className="w-full h-12 px-3 text-lg placeholder-transparent border rounded-md text-on-primary-container border-outline/50 outline-primary bg-primary-container/20 peer"
         />
         <label
           htmlFor="title"
-          className="absolute left-0 peer-placeholder-shown:top-2.5 peer-placeholder-shown:left-3.5 peer-focus:first-line:-top-3.5 peer-placeholder-shown:text-gray-400 peer-placeholder-shown:text-lg text-sm -top-6 transition-all"
+          className="absolute left-0 peer-placeholder-shown:top-2.5 peer-placeholder-shown:left-3.5 peer-focus:first-line:-top-3.5 peer-placeholder-shown:text-outline/60 peer-placeholder-shown:text-lg text-sm -top-6 transition-all"
         >
           Title
         </label>
         {touchedFields.title != null && errors.title != null && (
-          <span className="text-sm text-red-500">{errors.title.message}</span>
+          <span className="text-sm text-error">{errors.title.message}</span>
         )}
       </div>
       <div className="relative my-8">
@@ -74,29 +74,29 @@ const AddNewForm = ({ onSubmitted, onCancel }: { onSubmitted: () => void; onCanc
           placeholder="Note"
           {...register('note')}
           rows={2}
-          className="block w-full p-3 text-lg text-gray-900 placeholder-transparent border border-gray-300 rounded-md resize-y min-h-[3.5rem] bg-gray-50 outline-blue-700 focus:border-blue-500 peer"
+          className="block w-full p-3 text-lg text-on-primary-container placeholder-transparent border border-outline/50 rounded-md resize-y min-h-[3.5rem] bg-primary-container/20 outline-primary peer"
         />
         <label
           htmlFor="note"
-          className="absolute left-0 peer-placeholder-shown:top-3.5 peer-placeholder-shown:left-3.5 peer-focus:first-line:-top-3.5 peer-placeholder-shown:text-gray-400 peer-placeholder-shown:text-lg text-sm -top-6 transition-all"
+          className="absolute left-0 peer-placeholder-shown:top-3.5 peer-placeholder-shown:left-3.5 peer-focus:first-line:-top-3.5 peer-placeholder-shown:text-outline/60 peer-placeholder-shown:text-lg text-sm -top-6 transition-all"
         >
           Note
         </label>
         {touchedFields.note != null && errors.note != null && (
-          <span className="text-sm text-red-500">{errors.note.message}</span>
+          <span className="text-sm text-error">{errors.note.message}</span>
         )}
       </div>
       <div className="flex justify-center">
         <button
           type="submit"
-          className="w-24 h-12 text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2"
+          className="w-24 h-12 bg-primary hover:bg-primary-variant focus:ring-4 focus:ring-primary/50 font-medium rounded-lg text-sm px-5 py-2.5 text-center text-on-primary mr-2"
         >
           Save
         </button>
         <button
           type="button"
           onClick={onCancel}
-          className="w-24 h-12 text-blue-700 hover:text-white border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
+          className="w-24 h-12 text-primary bg-background hover:text-on-primary border border-primary hover:bg-primary-variant focus:ring-4 focus:ring-primary/50 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
         >
           Cancel
         </button>

--- a/src/routes/taskNew/index.tsx
+++ b/src/routes/taskNew/index.tsx
@@ -9,7 +9,7 @@ const NewTask = (): JSX.Element => {
   const onDismiss = (): void => navigate('/tasks');
   return (
     <div className="flex flex-col max-w-3xl px-5 m-auto">
-      <h1 id="label" className="py-4 text-slate-600">
+      <h1 id="label" className="py-4 text-on-surface">
         Add New Item
       </h1>
       <AddNewForm onSubmitted={onDismiss} onCancel={onDismiss} />
@@ -24,16 +24,16 @@ const NewTaskModal = (): JSX.Element => {
   return (
     <Dialog
       onDismiss={onDismiss}
-      className="flex flex-col w-full h-full max-w-3xl m-auto md:w-2/3 md:h-auto md:my-20"
+      className="flex flex-col w-full h-full max-w-3xl m-auto md:w-2/3 md:h-auto md:my-20 bg-surface text-on-surface"
       aria-labelledby="label"
     >
       <div className="flex items-center mb-10">
-        <h1 id="label" className="mr-auto text-slate-600">
+        <h1 id="label" className="mr-auto">
           Add New Item
         </h1>
         <button type="button" onClick={onDismiss}>
           <VisuallyHidden>Close</VisuallyHidden>
-          <XIcon className="w-10 h-10 text-slate-600" aria-hidden />
+          <XIcon className="w-10 h-10" aria-hidden />
         </button>
       </div>
 

--- a/src/routes/tasks/CtaButton/index.tsx
+++ b/src/routes/tasks/CtaButton/index.tsx
@@ -24,7 +24,7 @@ const CtaButton = ({ className = '' }: { className?: string }): JSX.Element => {
       type="button"
       aria-label="Add new item"
       onClick={() => navigate('/tasks/new', { state: { backgroundLocation: location } })}
-      className={`text-white transition duration-200 ease-in bg-blue-500 rounded-full shadow w-14 h-14 hover:bg-blue-700 active:shadow-lg focus:outline-none ${className}`}
+      className={`text-on-secondary transition duration-200 ease-in bg-secondary rounded-full shadow w-14 h-14 hover:bg-on-secondary-container active:shadow-lg focus:outline-none ${className}`}
     >
       <PlusIcon />
     </button>

--- a/src/routes/tasks/TodoItem/ActionBar.tsx
+++ b/src/routes/tasks/TodoItem/ActionBar.tsx
@@ -2,18 +2,18 @@ import { BellIcon, ColorSwatchIcon, PencilAltIcon, TrashIcon } from '@heroicons/
 
 const ActionBar = ({ className = '', onDelete }: { className?: string; onDelete: () => void }): JSX.Element => {
   return (
-    <div className={`flex gap-1 justify-end ${className}`}>
+    <div className={`flex gap-1 justify-end text-on-primary-container ${className}`}>
       <button type="button" className="group" disabled aria-label="Set Reminder">
-        <BellIcon className="w-6 h-6 p-1 group-disabled:text-slate-300 enabled:hover:border enabled:hover:border-gray-400 rounded-xl enabled:hover:bg-slate-300" />
+        <BellIcon className="w-6 h-6 p-1 group-disabled:text-on-primary-container/25" />
       </button>
       <button type="button" className="group" disabled aria-label="Background Options">
-        <ColorSwatchIcon className="w-6 h-6 p-1 group-disabled:text-slate-300 enabled:hover:border enabled:hover:border-gray-400 rounded-xl enabled:hover:bg-slate-300" />
+        <ColorSwatchIcon className="w-6 h-6 p-1 group-disabled:text-on-primary-container/25" />
       </button>
       <button type="button" className="group" disabled aria-label="Edit Item">
-        <PencilAltIcon className="w-6 h-6 p-1 group-disabled:text-slate-300 enabled:hover:border enabled:hover:border-gray-400 rounded-xl enabled:hover:bg-slate-300" />
+        <PencilAltIcon className="w-6 h-6 p-1 group-disabled:text-on-primary-container/25" />
       </button>
       <button type="button" onClick={onDelete} aria-label="Delete Item">
-        <TrashIcon className="w-6 h-6 p-1 hover:border hover:border-gray-400 rounded-xl hover:bg-slate-300" />
+        <TrashIcon className="w-6 h-6 p-1 hover:border hover:border-secondary rounded-xl hover:bg-secondary-container hover:text-on-secondary-container" />
       </button>
     </div>
   );

--- a/src/routes/tasks/TodoItem/index.tsx
+++ b/src/routes/tasks/TodoItem/index.tsx
@@ -29,12 +29,17 @@ const TodoItem = ({
   if (!isTouchEnabled) {
     return (
       <li className="w-full mb-3 group last:mb-20 xs:w-56 md:w-60">
-        <div className="px-3 border rounded-lg bg-[#F5F9FF] border-slate-300">
-          <h3 className={`${data.done ? 'line-through text-[#6B7385]' : ''}`}>{`Lorem Ipsum #${data.id}`}</h3>
-          <label htmlFor={data.id} className={`flex line-clamp-3 ${data.done ? 'line-through text-[#6B7385]' : ''}`}>
+        <div className="px-3 transition-colors border rounded-lg bg-primary-container border-outline text-on-primary-container">
+          <h3
+            className={`${data.done ? 'line-through text-on-primary-container/60' : ''}`}
+          >{`Lorem Ipsum #${data.id}`}</h3>
+          <label
+            htmlFor={data.id}
+            className={`flex line-clamp-3 ${data.done ? 'line-through text-on-primary-container/60' : ''}`}
+          >
             <input
               type="checkbox"
-              className="flex-initial mx-2"
+              className="flex-initial mx-2 accent-secondary"
               id={data.id}
               checked={data.done}
               onChange={toggleItem}
@@ -42,7 +47,7 @@ const TodoItem = ({
             {data.task}
           </label>
           <ActionBar
-            className="group-focus-within:opacity-100 group-hover:opacity-100 mt-1.5 opacity-0 transition-opacity duration-500"
+            className="my-1 transition-opacity duration-500 opacity-0 group-focus-within:opacity-100 group-hover:opacity-100"
             onDelete={deleteItem}
           />
         </div>
@@ -53,17 +58,21 @@ const TodoItem = ({
   return (
     <li className="w-full mb-3 last:mb-20 xs:w-56 md:w-60">
       <SwipeToAction
-        className="bg-[#F5F9FF] border rounded-lg border-slate-300 px-3 pb-3"
+        className="px-3 pb-3 transition-colors border rounded-lg border-outline bg-primary-container text-on-primary-container"
         onTap={toggleItem}
         onSwipedLeft={deleteItem}
         onSwipedRight={deleteItem}
         leftChildren={<TrashIcon className="w-6 h-6" />}
-        leftChildrenClassName="bg-red-700 text-white border rounded-lg"
+        leftChildrenClassName="bg-error-container text-on-error-container border border-outline rounded-lg"
         rightChildren={<TrashIcon className="w-6 h-6" />}
-        rightChildrenClassName="bg-red-700 text-white border rounded-lg"
+        rightChildrenClassName="bg-error-container text-on-error-container border border-outline rounded-lg"
       >
-        <h3 className={`${data.done ? 'line-through text-[#6B7385]' : ''}`}>{`Lorem Ipsum #${data.id}`}</h3>
-        <label className={`flex line-clamp-3 ${data.done ? 'line-through text-[#6B7385]' : ''}`}>{data.task}</label>
+        <h3
+          className={`${data.done ? 'line-through text-on-primary-container/60' : ''}`}
+        >{`Lorem Ipsum #${data.id}`}</h3>
+        <label className={`flex line-clamp-3 ${data.done ? 'line-through text-on-primary-container/60' : ''}`}>
+          {data.task}
+        </label>
       </SwipeToAction>
     </li>
   );

--- a/src/routes/tasks/Todos/index.tsx
+++ b/src/routes/tasks/Todos/index.tsx
@@ -1,10 +1,14 @@
+import { EmojiSadIcon } from '@heroicons/react/outline';
 import Masonry from 'react-masonry-component';
+import { useAtom } from 'jotai';
 import { convertRemToPixels } from '../../../utils';
 import { TodoItem } from '../TodoItem';
 import { useTodos } from './useTodos';
+import { queryAtom } from '../../layout/Header';
 
 const Todos = (): JSX.Element => {
   const { data, isFetching, sentryRef } = useTodos();
+  const [query, setQuery] = useAtom(queryAtom);
   const masonryOptions = {
     gutter: convertRemToPixels(0.75),
     stagger: '0.03s',
@@ -12,15 +16,32 @@ const Todos = (): JSX.Element => {
   };
 
   return (
-    <div className="p-1.5">
+    <div className="p-1.5 bg-background transition-colors min-h-screen">
       <Masonry elementType="ul" options={masonryOptions}>
         {data?.pages.map((page) => page.todos?.map((todo) => <TodoItem key={todo?.id} data={todo} />))}
         {isFetching && (
           <li ref={sentryRef}>
-            <h3>Loading...</h3>
+            <h3 className="text-on-background">Loading...</h3>
           </li>
         )}
       </Masonry>
+      {!isFetching && (data?.pages.length === 0 || data?.pages[0].todos?.length === 0) && (
+        <div className="flex items-center justify-center min-h-screen pb-40 text-on-background">
+          <div className="flex flex-col items-center">
+            <EmojiSadIcon className="w-40 h-40" />
+            <span>No items available</span>
+            {query !== '' && (
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                className="text-primary bg-background hover:text-on-primary border border-primary hover:bg-primary-variant focus:ring-4 focus:ring-primary/50 font-medium rounded-lg text-sm px-5 py-2.5 text-center mt-2"
+              >
+                Reset Search
+              </button>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import MatchMediaMock from 'jest-matchmedia-mock';
+
+// eslint-disable-next-line no-new
+new MatchMediaMock();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,49 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
+const withOpacityValue = (variable) => {
+  return ({ opacityValue }) => {
+    if (opacityValue === undefined) {
+      return `rgb(var(${variable}))`;
+    }
+    return `rgb(var(${variable}) / ${opacityValue})`;
+  };
+};
+
 module.exports = {
+  darkMode: 'class',
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
     screens: {
       xs: '480px',
       ...defaultTheme.screens,
+    },
+    colors: {
+      transparent: 'transparent',
+      current: 'currentColor',
+      primary: withOpacityValue('--color-primary'),
+      'primary-variant': withOpacityValue('--color-primary-variant'),
+      'on-primary': withOpacityValue('--color-on-primary'),
+      'primary-container': withOpacityValue('--color-primary-container'),
+      'on-primary-container': withOpacityValue('--color-on-primary-container'),
+      secondary: withOpacityValue('--color-secondary'),
+      'on-secondary': withOpacityValue('--color-on-secondary'),
+      'secondary-container': withOpacityValue('--color-secondary-container'),
+      'on-secondary-container': withOpacityValue('--color-on-secondary-container'),
+      tertiary: withOpacityValue('--color-tertiary'),
+      'on-tertiary': withOpacityValue('--color-on-tertiary'),
+      'tertiary-container': withOpacityValue('--color-tertiary-container'),
+      'on-tertiary-container': withOpacityValue('--color-on-tertiary-container'),
+      error: withOpacityValue('--color-error'),
+      'on-error': withOpacityValue('--color-on-error'),
+      'error-container': withOpacityValue('--color-error-container'),
+      'on-error-container': withOpacityValue('--color-on-error-container'),
+      background: withOpacityValue('--color-background'),
+      'on-background': withOpacityValue('--color-on-background'),
+      surface: withOpacityValue('--color-surface'),
+      'on-surface': withOpacityValue('--color-on-surface'),
+      outline: withOpacityValue('--color-outline'),
+      'surface-variant': withOpacityValue('--color-surface-variant'),
+      'on-surface-variant': withOpacityValue('--color-on-surface-variant'),
     },
     extend: {},
   },


### PR DESCRIPTION
- Add support for dark mode via the tailwind "class" strategy (choice is persisted in local storage)
- Reworked app theming to not use tailwind default colors; instead introduced a [material design palette](https://material-foundation.github.io/material-theme-builder/#/custom) colors (primary / secondary / tertiary and their respective variations) -- this simulates a real-world "branded" app scenario.
- Colors are consumed in the form of css variables as they are reactive (when theme is changed, new palette is applied immediately with css transitions)
