### PR TITLE
fix: handle fakeQL 424 response code

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
+/public/mockServiceWorker.js
 /src/generated/**/*.ts
 *.config.js

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.41.0).
+ * Mock Service Worker (0.42.0).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -23,6 +23,11 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
       throw new Error(message);
     }
 
+    // HACK: 424 fakeQL response threw a raw error not following the JSON API spec
+    if (json.error) {
+      throw new Error(json.error);
+    }
+
     return json.data;
   }
 }


### PR DESCRIPTION
fakeQL is having stability issues recently and intermittently throws a 424 "db connection failed" error. However, the server response is not following the JSON API spec (no "errors" field) so a workaround is needed in the auto-generated code to handle this.